### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "fix": "npx prettier . --write"
   },
   "devDependencies": {
-    "prettier": "^2.8.7"
+    "prettier": "npm:prettier@latest"
   }
 }


### PR DESCRIPTION
Reference only the tag that you want to auto upgradeTo the package-lock.json stores the exact current version only pin if needed reduces maintenance cheers.