### PR TITLE
feat: add support for SQLite sahpool VFS

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -4,6 +4,7 @@
   let main = null;
   let mainInnerHTML = '';
   const mainEmptyHTML = '<span>🫙</span> Origin Private File System is empty.';
+  const openDirectories = new Set();
 
   let interval = null;
 
@@ -41,6 +42,14 @@
           details.classList.add('root');
           summary.textContent = ' ';
         } else {
+          details.open = openDirectories.has(value.relativePath);
+          details.ontoggle = (event) => {
+            if (details.open) {
+              openDirectories.add(value.relativePath);
+            } else {
+              openDirectories.delete(value.relativePath);
+            }
+          }
           const directoryNameSpan = document.createElement('span');
           directoryNameSpan.textContent = key;
           const deleteSpan = document.createElement('span');

--- a/devtools.js
+++ b/devtools.js
@@ -92,7 +92,7 @@
         fileNameSpan.addEventListener('click', (event) => {
           browser.tabs.sendMessage(browser.devtools.inspectedWindow.tabId, {
             message: 'saveFile',
-            data: value.relativePath,
+            data: value,
           });
         });
         const sizeSpan = document.createElement('span');

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "OPFS Explorer",
   "description": "OPFS Explorer is a Chrome DevTools extension that allows you to explore the Origin Private File System (OPFS) of a web application.",
   "manifest_version": 3,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "devtools_page": "devtools.html",
   "content_scripts": [
     {


### PR DESCRIPTION
This PR adds support for decoding of the [new OPFS-sahpool virtual filesystem](https://sqlite.org/wasm/doc/tip/persistence.md#vfs-opfs-sahpool) of SQLite.
Instead of showing opaque encoded files, it shows the VFS entries and allows downloading the actual file content, instead of the encoded one.

Also, keeps the same directories open in the tree view when refreshing. It can be frustrating if the filesystem is modified often.
