### PR TITLE
[feat] Download All

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -242,7 +242,7 @@
       }
     } else if (request.message === 'downloadAll') {
       try {
-        const download = await showDirectoryPicker({mode: "readwrite", startIn: "downloads"});
+        const download = await showDirectoryPicker({mode: 'readwrite', startIn: 'downloads'});
         const root = await navigator.storage.getDirectory();
         await downloadDirectoryEntriesRecursive(root, '.', download);
         sendResponse({result: "success"}); 

--- a/contentscript.js
+++ b/contentscript.js
@@ -120,7 +120,6 @@
       const nestedPath = `${relativePath}/${handle.name}`;
       if (handle.kind === 'file') {
         const fileHandle = getFileHandle(nestedPath).handle;
-        console.log(nestedPath.split("/").slice(-1)[0]);
         try {
           const sahPoolName =
           directoryHandle.name === '.opaque'

--- a/contentscript.js
+++ b/contentscript.js
@@ -245,7 +245,7 @@
         const download = await showDirectoryPicker({mode: 'readwrite', startIn: 'downloads'});
         const root = await navigator.storage.getDirectory();
         await downloadDirectoryEntriesRecursive(root, '.', download);
-        sendResponse({result: "success"}); 
+        sendResponse({result: 'success'}); 
       } catch (error) {
         console.error(error.name, error.message);
         sendResponse({ error: error.message });

--- a/devtools.js
+++ b/devtools.js
@@ -222,6 +222,26 @@
           return;
         }
         const div = document.createElement('div');
+        const downloadAllSpan = document.createElement('span');
+        downloadAllSpan.classList.add('download-all');
+        downloadAllSpan.textContent = 'Download All';
+        downloadAllSpan.title = 'Download All';
+        downloadAllSpan.addEventListener('click', (event) => {
+          browser.tabs.sendMessage(
+            browser.devtools.inspectedWindow.tabId,
+            {
+              message: 'downloadAll'
+            },
+            (response) => {
+              if (response.error) {
+                errorDialog.querySelector('p').textContent =
+                  response.error;
+                return errorDialog.showModal();
+              }
+            },
+          );
+        });
+        div.append(downloadAllSpan);
         createTreeHTML(response.structure, div);
         if (!main) {
           return;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "OPFS Explorer",
   "description": "OPFS Explorer is a Chrome DevTools extension that allows you to explore the Origin Private File System (OPFS) of a web application.",
   "manifest_version": 3,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "devtools_page": "devtools.html",
   "content_scripts": [
     {


### PR DESCRIPTION
This PR is a new version of #16. It adds a Download All button but does not create a zip file and instead writes directly to a folder of the user's choosing, which should hopefully reduce overall RAM usage while exporting.

To reduce overhead, it still may be worth looking into ways to dynamically add the content script to pages when the OPFS Explorer Devtools Pane is opened, instead of running them on all loaded pages.

The Download All feature still struggles when there is a large number (hundreds of thousands) of files stored in the OPFS. If you're only looking to export and not browse the data, this issue can be partially fixed by temporarily commenting out most of the body of the getDirectoryEntriesRecursive function and making it a stub.

I have not tested the support for SAH/`.opaque` files but I don't expect there to be any issues with it.

This PR also updates the version in the manifest from 1.5.0 to 1.6.0.