### PR TITLE
Fix running on localhost

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -212,7 +212,7 @@
       browser.devtools.inspectedWindow.tabId,
       { message: 'getDirectoryStructure' },
       (response) => {
-        if (!response.structure) {
+        if (!response?.structure) {
           return;
         }
         // Naive check to avoid unnecessary DOM updates.


### PR DESCRIPTION
This change was needed to get the extension to work on localhost. I'm not sure if this is the correct way, just something I did to make this work for myself.

This line was originally changed to unwrap the optional to make it work on localhost - https://github.com/tomayac/opfs-explorer/issues/2

Later on that change was reverted, perhaps accidentally?, in this commit - https://github.com/tomayac/opfs-explorer/commit/096540a22b1597d13c23ac68635659866d7624ea#diff-4389719a5fd3863f3281e887219a4c1350941eb726f9559d4a043cb8cbb06e01

By reintroducing the optional unwrap, I am able to get it to work on localhost.

---

p.s. A big thank you, @tomayac, for your work on the web platform. It is much appreciated! 🙏