### PR TITLE
Add Directory Download Functionality to OPFS Explorer

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -192,7 +192,7 @@
         },
       };
       sendResponse({ structure: rootStructure });
-    } else if (request.message === 'saveFile') {
+    } else if (request.message === 'downloadFile') {
       const fileHandle = getFileHandle(request.data.relativePath).handle;
       try {
         const handle = await showSaveFilePicker({

--- a/devtools.js
+++ b/devtools.js
@@ -54,6 +54,26 @@
           const directoryNameSpan = document.createElement('span');
           directoryNameSpan.classList.add('directory-name');
           directoryNameSpan.textContent = key;
+          const downloadButton = document.createElement('button');
+          downloadButton.classList.add('text-button');
+          downloadButton.textContent = '💾';
+          downloadButton.title = 'Download directory';
+          downloadButton.classList.add('download');
+          downloadButton.addEventListener('click', (event) => {
+            browser.tabs.sendMessage(
+              browser.devtools.inspectedWindow.tabId,
+              {
+                message: 'downloadDirectory',
+                data: value.relativePath,
+              },
+              (response) => {
+                if (response.error) {
+                  errorDialog.querySelector('p').textContent = response.error;
+                  return errorDialog.showModal();
+                }
+              },
+            );
+          });
           const deleteButton = document.createElement('button');
           deleteButton.classList.add('text-button');
           deleteButton.textContent = '🗑️';
@@ -87,7 +107,7 @@
             );
             confirmDialog.showModal();
           });
-          summary.append(directoryNameSpan, deleteButton);
+          summary.append(directoryNameSpan, downloadButton, deleteButton);
         }
         const div = document.createElement('div');
         details.append(div);
@@ -169,6 +189,17 @@
             editDialog.showModal();
           });
         }
+        const downloadButton = document.createElement('button');
+        downloadButton.classList.add('text-button');
+        downloadButton.textContent = '💾';
+        downloadButton.title = 'Download file';
+        downloadButton.classList.add('download');
+        downloadButton.addEventListener('click', (event) => {
+          browser.tabs.sendMessage(browser.devtools.inspectedWindow.tabId, {
+            message: 'saveFile',
+            data: value,
+          });
+        });
         const deleteButton = document.createElement('button');
         deleteButton.classList.add('text-button');
         deleteButton.textContent = '🗑️';
@@ -202,7 +233,13 @@
           );
           confirmDialog.showModal();
         });
-        div.append(fileNameButton, sizeSpan, editButton, deleteButton);
+        div.append(
+          fileNameButton,
+          sizeSpan,
+          editButton,
+          downloadButton,
+          deleteButton,
+        );
       }
     }
   };

--- a/devtools.js
+++ b/devtools.js
@@ -126,7 +126,7 @@
         fileNameButton.textContent = key;
         fileNameButton.addEventListener('click', (event) => {
           browser.tabs.sendMessage(browser.devtools.inspectedWindow.tabId, {
-            message: 'saveFile',
+            message: 'downloadFile',
             data: value,
           });
         });
@@ -196,7 +196,7 @@
         downloadButton.classList.add('download');
         downloadButton.addEventListener('click', (event) => {
           browser.tabs.sendMessage(browser.devtools.inspectedWindow.tabId, {
-            message: 'saveFile',
+            message: 'downloadFile',
             data: value,
           });
         });


### PR DESCRIPTION
## Description

First of all, thank you for creating OPFS Explorer; it's a fantastic tool. I've been developing a web application that utilizes the Origin Private File System (OPFS), and your tool has been incredibly helpful during this process.

I found that I needed the ability to download directories as a whole, so I have implemented this feature and would like to contribute it back to the project.

## Changes Made

- **Added Directory Download Feature:**
  - Implemented a new functionality to download directories recursively.
  - Modified `contentscript.js` to handle a new message `'downloadDirectory'`, which initiates the download of the specified directory.
  - Ensured that `fileHandles` and `directoryHandles` are populated before invoking `downloadDirectoryEntriesRecursive`, to maintain consistency with the existing code structure.

- **User Interface Enhancements:**
  - Updated `devtools.js` to add a download button (💾) next to directories and files in the UI. Users can click this button to download the entire directory or file.
  - Chose the floppy disk emoji (💾) as the icon for the download button. If you prefer a different icon or have any suggestions, please let me know, and I can update it accordingly.

<img width="309" alt="opfs-explorer_add-download-button" src="https://github.com/user-attachments/assets/638c90ce-2016-455b-8b6a-70c88b726b51">

## Feedback Request

I would appreciate it if you could review this addition and let me know your thoughts on the implementation.
Do you think this approach aligns well with the project's direction?

Also, regarding the icon choice for the download button, if you have a preferred icon or style guidelines, please let me know, and I'm happy to make adjustments.

Thank you for considering this pull request!