### PR TITLE
Add debounced name search to the OPFS Explorer panel

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -11,6 +11,42 @@
 
   let lastLength = 0;
 
+  let searchTerm = '';
+
+  // Returns a pruned copy of the structure: keeps files whose name matches
+  // `term`, and any directory that (recursively) contains a match. The Root
+  // directory is always kept so its toolbar buttons remain available.
+  const filterStructure = (structure, term) => {
+    if (!term) return structure;
+    const out = {};
+    for (const [key, value] of Object.entries(structure)) {
+      if (value.kind === 'directory') {
+        const isRoot = value.relativePath === '.';
+        const entries = filterStructure(value.entries, term);
+        const nameMatches = key.toLowerCase().includes(term);
+        if (isRoot || nameMatches || Object.keys(entries).length) {
+          out[key] = { ...value, entries };
+          // Auto-expand directories that lead to a match.
+          if (!isRoot && Object.keys(entries).length) {
+            openDirectories.add(value.relativePath);
+          }
+        }
+      } else if (key.toLowerCase().includes(term)) {
+        out[key] = value;
+      }
+    }
+    return out;
+  };
+
+  // Debounce helper so we don't re-render the tree on every keystroke.
+  const debounce = (fn, delay) => {
+    let timer = null;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  };
+
   const readableSize = (size) => {
     if (size === 0) return '0B';
     const i = Math.floor(Math.log(size) / Math.log(1024));
@@ -88,7 +124,8 @@
                     },
                     (response) => {
                       if (response.error) {
-                        errorDialog.querySelector('p').textContent = response.error;
+                        errorDialog.querySelector('p').textContent =
+                          response.error;
                         return errorDialog.showModal();
                       }
                       // Refresh the tree after deletion
@@ -103,7 +140,6 @@
           }
 
           summary.append(downloadButton, deleteButton);
-
         } else {
           details.open = openDirectories.has(value.relativePath);
           details.ontoggle = (event) => {
@@ -318,8 +354,18 @@
           main.innerHTML = mainEmptyHTML;
           return;
         }
+        const filtered = filterStructure(response.structure, searchTerm);
+        // While searching, the Root is always kept; treat an empty Root as
+        // "no matches" rather than rendering a bare toolbar.
+        if (searchTerm) {
+          const root = filtered['.'];
+          if (!root || Object.keys(root.entries).length === 0) {
+            main.innerHTML = '<span>🔍</span> No matching files or folders.';
+            return;
+          }
+        }
         const div = document.createElement('div');
-        createTreeHTML(response.structure, div);
+        createTreeHTML(filtered, div);
         if (!main) {
           return;
         }
@@ -353,6 +399,14 @@
         if (!mainInnerHTML) {
           mainInnerHTML = main.innerHTML;
         }
+
+        const search = extPanelWindow.document.body.querySelector('.search');
+        search.value = searchTerm;
+        search.oninput = debounce(() => {
+          searchTerm = search.value.trim().toLowerCase();
+          lastLength = 0; // Force a re-render past the no-op short-circuit.
+          refreshTree();
+        }, 200);
 
         lastLength = 0;
 

--- a/panel.html
+++ b/panel.html
@@ -16,6 +16,19 @@
           --secondary-text-color-color: #d4d4d4;
         }
       }
+      .search {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.4rem 0.6rem;
+        border: none;
+        border-bottom: 1px solid var(--background-color);
+        background: Canvas;
+        color: inherit;
+        font: inherit;
+      }
       main {
         background-image: linear-gradient(
           to bottom,
@@ -123,6 +136,12 @@
     </style>
   </head>
   <body>
+    <input
+      type="search"
+      class="search"
+      placeholder="🔍 Filter files & folders…"
+      autocomplete="off"
+    />
     <main>
       <span class="spinner">⏳</span> Analyzing Origin Private File System
     </main>


### PR DESCRIPTION
## Context

We're heavy users of opfs, with our application storing many files in there under specific resource identifiers. When debugging your extension is critical for us to be able to inspect and download locally some of the db files we store in opfs! Nevertheless, we've hit a wall when we have many. It's difficult to find the ones we need. Hence, I've asked uncle Claude to see if we can add a little search feature. 

<img width="838" height="317" alt="image" src="https://github.com/user-attachments/assets/0de275ff-463c-4c43-b44b-c5ebda88de03" />


## What

Adds a simple **name search** to the DevTools panel: a sticky input above the tree that filters files and folders by name (case-insensitive substring match).

## Why

OPFS trees can get large (e.g. SQLite-WASM apps with many segment files). Filtering to find a specific file/folder is much faster than scrolling and manually expanding directories.

## How

- New `filterStructure(structure, term)` recursively prunes the tree: keeps files whose names match, and any directory that (recursively) contains a match. Matching directories are auto-expanded; the Root is always kept so its toolbar stays available.
- Filtering happens at **render time** in `refreshTree`, so the existing 3s poll keeps the filtered view in place rather than fighting it.
- The input is **debounced (200ms)** so the tree isn't rebuilt on every keystroke.
- Empty result shows a "🔍 No matching files or folders." message; clearing the box restores the full tree.

No new permissions, messages, or content-script changes — purely panel-side (`panel.html` + `devtools.js`).

## Testing

Loaded unpacked, seeded OPFS with a few files and a `logs/` folder:
- Typing `json` narrows to `config.json`
- Typing `log` auto-expands `logs/` and shows `app.log`
- Gibberish shows the no-match message
- Clearing restores the tree
- Fast typing only re-renders ~200ms after input stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)